### PR TITLE
Work with public key grantees

### DIFF
--- a/go/extension/chains/near/near.go
+++ b/go/extension/chains/near/near.go
@@ -22,10 +22,15 @@ func isNearAcct(acct string) bool {
 		strings.HasSuffix(acct, ".shardnet") || strings.HasSuffix(acct, ".guildnet") {
 		return true
 	}
-	if len(acct) != 64 {
+
+	return isNearImplicitAddress(acct)
+}
+
+func isNearImplicitAddress(s string) bool {
+	if len(s) != 64 {
 		return false
 	}
-	_, err := hex.DecodeString(acct)
+	_, err := hex.DecodeString(s)
 	return err == nil
 }
 

--- a/go/extension/chains/near/near_test.go
+++ b/go/extension/chains/near/near_test.go
@@ -31,6 +31,17 @@ func (sc *stubClient) ContractViewCallFunction(ctx context.Context, accountID, m
 	}, nil
 }
 
+func TestNearAddressToPublicKey(t *testing.T) {
+	pk, err := nearAddressToPublicKey("7946fb2f23ddd5e137de52d8e20abda8f8f5aa03de5c97c3178ab6bf73732ce8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := "ed25519:9AR7EocrvHrpxEbUPiZ5pGAknzLQ6gRCX7odntbJ6MWo"
+	if pk != target {
+		t.Errorf("wanted %v got %v", target, pk)
+	}
+}
+
 func TestBackend(t *testing.T) {
 	wantHeight := uint64(123413241234)
 	cl := &stubClient{
@@ -47,7 +58,7 @@ func TestBackend(t *testing.T) {
 		t.Errorf("wanted height %v got %v", wantHeight, height)
 	}
 
-	grantee := "jchappelow.testnet"
+	grantee := "7946fb2f23ddd5e137de52d8e20abda8f8f5aa03de5c97c3178ab6bf73732ce8"
 	registry := "grants.jchappelow.testnet"
 	dataID := "blah"
 


### PR DESCRIPTION
This adds support for the extension to automatically translate the address to a public key, in order to support the changes we're about to introduce to the NEAR grants contract.